### PR TITLE
example/etcd: 4 times faster on 5 VMs

### DIFF
--- a/.misc/unsupported/nmzswarm-gke.sh
+++ b/.misc/unsupported/nmzswarm-gke.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Usage:
+#  $ docker build -t etcd-nmzswarm ./example/etcd
+#  $ gcloud container clusters get-credentials <CLUSTER> \
+#    --zone <ZONE> --project <PROJECT_ID>
+#  $ PARALLEL=50 <THIS_SCRIPT> etcd-nmzswarm
+set -e # exit on an error
+
+: ${PROJECT:=$(gcloud config list --format='value(core.project)')}
+: ${GCR:=asia.gcr.io}
+IMAGE=$1
+: ${TAG:=$(date +%s)}
+: ${PARALLEL=10}
+: ${LOGS=/tmp/logs}
+: ${NMZSWARM=nmzswarm}
+
+set -x
+docker tag $1 $GCR/$PROJECT/$IMAGE:$TAG
+time gcloud docker --server $GCR -- push $GCR/$PROJECT/$IMAGE:$TAG
+time $NMZSWARM --driver=k8s run --ui simple --parallel $PARALLEL --logs $LOGS $GCR/$PROJECT/$IMAGE:$TAG
+set +x

--- a/example/etcd/Dockerfile
+++ b/example/etcd/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:latest
 
-RUN apt-get update && apt-get install -y libpcap-dev
+RUN apt-get update && apt-get install -y time libpcap-dev
 
 # Aug 29, 2016
 ARG ETCD_CHECKOUT=e53b99588a05d1f4ef172c178d4ed8e8106b8be4
@@ -10,7 +10,13 @@ RUN mkdir -p $GOPATH/src/github.com/coreos && \
  cd etcd && \
  git checkout $ETCD_CHECKOUT
 WORKDIR $GOPATH/src/github.com/coreos/etcd
-RUN ./build && cp -r bin gopath
+
+# Pre-compile test binaries at once, using go-test-helper.sh
+# NOTE: rafttest has been disabled by default (https://github.com/coreos/etcd/pull/5707)
+RUN ./build && \
+  go list -f '{{if len .TestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v rafttest > /pkgs.txt
+ADD go-test-helper.sh /
+RUN GOPATH=$(pwd)/gopath time go test -p $(($(nproc)*2)) -cover -race -v -exec /go-test-helper.sh $(cat /pkgs.txt)
 
 ADD NamazuSwarmfile /
 RUN chmod +x /NamazuSwarmfile

--- a/example/etcd/NamazuSwarmfile
+++ b/example/etcd/NamazuSwarmfile
@@ -1,31 +1,69 @@
-#!/bin/sh
+#!/bin/bash
 set -e # exit on an error
-GO_TEST="go test -race -cover -run Test"
+ATOZ=$(perl -e 'foreach(A..Z){print "$_ "}')
+export PATH=$(pwd)/bin:$PATH
 do_info_jsonl(){
     echo '{"API":"v0"}'
 }
-enum_pkgs(){
-    # rafttest has been disabled by default (https://github.com/coreos/etcd/pull/5707)
-    go list -f '{{if len .TestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v rafttest
+test_pkg(){
+    # TODO: support other flags
+    pkg=$1
+    regexp=Test
+    [ x$2 != x ] && regexp=$2
+    testbin=/testbin/$pkg/$(basename $pkg).test
+    (cd $GOPATH/src/$pkg && $testbin -test.short -test.run $regexp)
+}
+command_jsonl(){
+    echo "{\"Command\": \"$@\"}"
 }
 do_enum_jsonl(){
-    enum_pkgs | sed -e "s/\(.*\)/{\"Command\": \"$GO_TEST \1\"}/g"
-}
-do_exec_all(){
-    pkgs=$(enum_pkgs)
-    export GOPATH=$GOPATH/src/github.com/coreos/etcd/gopath
-    set -x
-    $GO_TEST $pkgs
-    set +x
+    for pkg in $(cat /pkgs.txt | grep -v integration | grep -v e2e); do
+	command_jsonl $pkg
+    done
+    pkg=github.com/coreos/etcd/e2e
+
+    command_jsonl $pkg TestV2
+    command_jsonl $pkg TestV3
+    command_jsonl $pkg TestCtlV3WatchClient
+    command_jsonl $pkg TestCtlV3WatchInteractiveClient    
+    for f in $ATOZ; do
+	command_jsonl $pkg TestCtlV2$f
+	[ $f != W ] && command_jsonl $pkg TestCtlV3$f
+	[ $f != C ] && [ $f != V ] && command_jsonl $pkg Test$f
+    done
+
+    pkg=github.com/coreos/etcd/integration
+    command_jsonl $pkg TestV2
+    for f in $ATOZ; do
+	command_jsonl $pkg TestV3$f
+	[ $f != V ] && command_jsonl $pkg Test$f
+    done    
 }
 do_exec(){
-    export GOPATH=$GOPATH/src/github.com/coreos/etcd/gopath
-    $@
+    test_pkg $@
+}
+do_exec_all(){
+    # compile packages and execute at once.
+    # go itself does some parallelization automatically.
+    # https://groups.google.com/forum/#!topic/golang-nuts/oAOM7_JB4_8
+    # so it is faster than exec_all_seq.
+    cp -r bin gopath/
+    GOPATH=$(pwd)/gopath \
+	  go test -race -cover -short -run Test $(cat /pkgs.txt)
+}
+do_exec_all_seq(){
+    # execute precompiled tests sequentially. (SLOW!)
+    for pkg in $(cat /pkgs.txt); do
+	set +e; set-x
+	time do_exec $pkg
+	set +x; set -e
+    done
 }
 case "$1" in
     "info-jsonl" ) do_info_jsonl;;
     "enum-jsonl" ) do_enum_jsonl;;
     "exec" ) shift; do_exec "$@";;
     "_exec_all" ) do_exec_all;; # _exec_all is not an API call. It is a toy for humans (e.g. benchmark)
+    "_exec_all_seq" ) do_exec_all_seq;; # ditto
     * ) echo "Usage: $(basename $0) info-jsonl | enum-jsonl | exec [COMMAND] | _exec_all" >&2 ; exit 1;;
 esac

--- a/example/etcd/go-test-helper.sh
+++ b/example/etcd/go-test-helper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+bin=$1
+pkgdir=$(echo $(pwd) | sed -e s@$GOPATH/src@@g)
+dstdir=/testbin$pkgdir
+echo "Copying $bin to $dstdir (NOT executing!)"
+mkdir -p $dstdir
+cp $bin $dstdir

--- a/nmzswarm/progress/summarizer.py
+++ b/nmzswarm/progress/summarizer.py
@@ -1,5 +1,6 @@
 """Event sequence summarizer
 """
+import time
 from nmzswarm.progress.event import Event, JobEvent
 
 
@@ -9,16 +10,26 @@ class Summarizer:
     def __init__(self) -> None:
         self.completed = 0
         self.failed = 0
+        self.job_started = {}  # type: Dict[str, float]
+        self.job_took = {}  # type: Dict[str, float]
 
     def handle_event(self, ev: Event) -> None:
         """handles an event"""
         if isinstance(ev, JobEvent):
-            if ev.finished:
+            job_id = ev.command
+            if not ev.finished:
+                self.job_started[job_id] = time.time()
+            else:
+                self.job_took[job_id] = time.time() - self.job_started[job_id]
                 self.completed += 1
                 if ev.code != 0:
                     self.failed += 1
 
     def __str__(self) -> str:
         """summarize the result"""
-        return 'Completed %d jobs (%d failed)' % \
+        s = 'Completed %d jobs (%d failed)\n' % \
             (self.completed, self.failed)
+        for k in sorted(self.job_took, key=self.job_took.get):
+            v = self.job_took[k]
+            s += '%s: took %f seconds (job creation..completion)\n' % (k, v)
+        return s


### PR DESCRIPTION
```
Experimental result:

VM: 4 CPUs, 15 GB RAM

1 VM (`docker run --rm etcd-nmzswarm /NamazuSwarmfile _exec_all`): about 4m
5 VMs, 80 containers: about 1m + init (pre-compilation time (50s) + gcr push time (50s))

So it is not so fast (just 4m vs 3m) for the first run... :-(
```

---

Close #1 
PTAL @mitake 
